### PR TITLE
bump-pkgrel: Also consider lower PKGBUILD version to be unbuilt.

### DIFF
--- a/bin/aprt-bump-pkgrel
+++ b/bin/aprt-bump-pkgrel
@@ -118,12 +118,12 @@ def main():
 	reverse_deps = aprt.reachability_table(aprt.reverse_neighbour_table(repository.values()))
 
 	# Add unbuilt packages, if requested.
-	# These will always be skipped (otherwise they weren't unbuilt),
-	# but together with options.reverse_deps it allows easy bumping
+	# These may have wrong pkgrels due to automatically recreated PKGBUILDs,
+	# and together with options.reverse_deps it also allows easy bumping
 	# of reverse dependencies of unbuilt packages.
 	if (options.unbuilt):
 		for pkgname, pkg in repository.items():
-			if srcinfo_db[pkgname].pkgbase.version() > pkg.version():
+			if srcinfo_db[pkgname].pkgbase.version() != pkg.version():
 				bump.add(pkgname)
 
 	updated = set()


### PR DESCRIPTION
Without this PR `bump-pkgrel` only considers PKGBUILDs with *higher* versions than the databse to be unbuilt. However, when we automatically recreate PKGBUILDs, they may have the same version and a lower pkgrel. This should be fixed by bump-pkgrel too.

This PR makes sure that any version that doesn't match the database is considered unbuilt. As a result, the pkgrel will automatically be bumped past the current database version and all is well.

